### PR TITLE
Take upload and download packet loss into account

### DIFF
--- a/modules/connectivity/ConnectionQuality.js
+++ b/modules/connectivity/ConnectionQuality.js
@@ -292,10 +292,9 @@ export default class ConnectionQuality {
         let quality = 100;
         let packetLoss;
 
-        // TODO: take into account packet loss for received streams
-
         if (this._localStats.packetLoss) {
-            packetLoss = this._localStats.packetLoss.upload;
+            // NOTE: Taking the sum of upload and download packetloss into account
+            packetLoss = this._localStats.packetLoss.upload + this._localStats.packetLoss.download;
 
             // Ugly Hack Alert (UHA):
             // The packet loss for the upload direction is calculated based on


### PR DESCRIPTION
Essentially reverting [this pr](https://github.com/jitsi/lib-jitsi-meet/pull/301) so that for the connection quality calculation we're _also_ looking at the download packet loss. Tested on Chrome, Firefox and Edge (MacOS) and see that this has the desired effect of dropping the connection quality to around 30 when introducing ~10% packet loss.